### PR TITLE
chore: cicd semantic release added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+# this allows you to use CircleCI's dynamic configuration feature
+setup: true
+
+orbs:
+  gravitee: gravitee-io/gravitee@2.0
+
+# our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
+# some workflow and job will not be triggered for tags (default CircleCI behavior)
+workflows:
+  setup_build:
+    when:
+      not: << pipeline.git.tag >>
+    jobs:
+      - gravitee/setup_plugin-build-config:
+          filters:
+            tags:
+              ignore:
+                - /.*/
+
+  setup_release:
+    when:
+      matches:
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        value: << pipeline.git.tag >>
+    jobs:
+      - gravitee/setup_plugin-release-config:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^[0-9]+\.[0-9]+\.[0-9]+$/%


### PR DESCRIPTION
This setup the circleci CICD semantic release
wait before https://github.com/gravitee-io/gravitee-risk-assessment-api/pull/4 to be merged

Need also to setup the circleci project
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-chore-cicd-semantic-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/risk/assessment/api/gravitee-risk-assessment-api/1.0.0-chore-cicd-semantic-release-SNAPSHOT/gravitee-risk-assessment-api-1.0.0-chore-cicd-semantic-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
