### PR TITLE
fix: typo on assessment message result

### DIFF
--- a/src/main/java/io/gravitee/risk/assessment/api/assessment/AssessmentResult.java
+++ b/src/main/java/io/gravitee/risk/assessment/api/assessment/AssessmentResult.java
@@ -23,7 +23,7 @@ package io.gravitee.risk.assessment.api.assessment;
 public class AssessmentResult<T> {
 
     private T result;
-    private Assessment assessement;
+    private Assessment assessment;
 
     public AssessmentResult() {}
 
@@ -32,7 +32,7 @@ public class AssessmentResult<T> {
     }
 
     public Assessment getAssessment() {
-        return assessement;
+        return assessment;
     }
 
     public AssessmentResult<T> setResult(T result) {
@@ -40,8 +40,8 @@ public class AssessmentResult<T> {
         return this;
     }
 
-    public AssessmentResult<T> setAssessment(Assessment assessement) {
-        this.assessement = assessement;
+    public AssessmentResult<T> setAssessment(Assessment assessment) {
+        this.assessment = assessment;
         return this;
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7555
https://github.com/gravitee-io/issues/issues/7657

**Description**

Fixes a typo in a POJO
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1-fix-typo-on-assessment-message-result-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/risk/assessment/api/gravitee-risk-assessment-api/1.0.1-fix-typo-on-assessment-message-result-SNAPSHOT/gravitee-risk-assessment-api-1.0.1-fix-typo-on-assessment-message-result-SNAPSHOT.zip)
  <!-- Version placeholder end -->
