### PR TITLE
chore(deps): upgrade dependencies 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@2.1
+  gravitee: gravitee-io/gravitee@2.4.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
   setup_release:
     when:
       matches:
-        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
         value: << pipeline.git.tag >>
     jobs:
       - gravitee/setup_lib-release-config:
@@ -32,4 +32,4 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/README.adoc
+++ b/README.adoc
@@ -1,16 +1,19 @@
 # Gravitee Risk Assessment Api
 
 ifdef::env-github[]
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-risk-assessment-api/blob/master/LICENSE.txt"]
 image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-risk-assessment-api/releases"]
+image:https://circleci.com/gh/gravitee-io/gravitee-risk-assessment-api.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-risk-assessment-api"]
+image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
 endif::[]
 
 ## Introduction
 
 This gravitee library contains all the necessary settings to communicate with the Gravitee Risk Assessment Service.
 
-It is currently composed of:
+It is currently composed of **gravitee-risk-assessment-api**,
+the common api to implement in your project which contains:
 
-- **gravitee-risk-assessment-api**: the common api to implement in your project:
   - The data model to use for settings
   - The data model to use for the evaluation data
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <plugin>
         <groupId>com.hubspot.maven.plugins</groupId>
         <artifactId>prettier-maven-plugin</artifactId>
-        <version>0.17</version>
+        <version>0.18</version>
         <configuration>
           <nodeVersion>12.13.0</nodeVersion>
           <prettierJavaVersion>1.6.1</prettierJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.gravitee</groupId>
     <artifactId>gravitee-parent</artifactId>
-    <version>20.2</version>
+    <version>21.0.0</version>
   </parent>
 
   <groupId>io.gravitee.risk.assessment.api</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-459


**Description**

This PR updates dependencies in the BOM 
BREAKING CHANGE due to parent 21.0.0
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-AM-459-risk-assessment-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/risk/assessment/api/gravitee-risk-assessment-api/2.0.0-AM-459-risk-assessment-api-SNAPSHOT/gravitee-risk-assessment-api-2.0.0-AM-459-risk-assessment-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
